### PR TITLE
Fix formatting in Wrapper Display implementation

### DIFF
--- a/guides/the-ultimate-guide-to-rust-newtypes.md
+++ b/guides/the-ultimate-guide-to-rust-newtypes.md
@@ -29,7 +29,7 @@ struct Wrapper(Vec<String>);
 
 impl fmt::Display for Wrapper {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "[{}]", self.0.join(", ")) }
+		write!(f, "[{}]", self.0.join(", "))
 	}
 }
 ```


### PR DESCRIPTION
From:
```rust
impl fmt::Display for Wrapper {
	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
		write!(f, "[{}]", self.0.join(", ")) }
	}
}
```

To:

```rust
impl fmt::Display for Wrapper {
	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
		write!(f, "[{}]", self.0.join(", ")) // <- here
	}
}
```